### PR TITLE
Change the order of privacy options in adobe connect bookings.

### DIFF
--- a/app/models/mybookings/adobe_connect_booking.rb
+++ b/app/models/mybookings/adobe_connect_booking.rb
@@ -6,7 +6,7 @@ module Mybookings
     validates :adobe_connect_meeting_room_id, :adobe_connect_meeting_privacy, presence: true
     validates :adobe_connect_participants, email_list: true
 
-    enum adobe_connect_meeting_privacy: [:closed, :semiopened, :opened]
+    enum adobe_connect_meeting_privacy: [:opened, :semiopened, :closed]
 
     delegate :name, :uuid, :url, to: :adobe_connect_meeting_room, prefix: true
 

--- a/app/views/mybookings/bookings/_resource_type_extension_adobeconnectextension_new.haml
+++ b/app/views/mybookings/bookings/_resource_type_extension_adobeconnectextension_new.haml
@@ -2,8 +2,16 @@
   .panel-body
     - selected_value = @booking.adobe_connect_meeting_room_name if @booking.adobe_connect_meeting_room
     = form.input :adobe_connect_meeting_room_id, collection: @meeting_rooms_names, selected: selected_value, hint: t('mybookings.bookings.hints.meeting_room_hint'), include_blank: false
-    = form.input :adobe_connect_meeting_privacy, as: :radio_buttons, include_blank: false, checked: 'closed', collection: Mybookings::AdobeConnectBooking.adobe_connect_meeting_privacies.keys.map {|key| [t("mybookings.bookings.privacies.#{key}_html"), key]}
-    = form.input :adobe_connect_participants, input_html: { rows: 3, value: @booking.adobe_connect_participants.join(', ') }, hint: t('mybookings.bookings.hints.participants_hint')
+    = form.input :adobe_connect_meeting_privacy,
+        as: :radio_buttons,
+        include_blank: false,
+        input_html: { class: 'js-booking-privacy-type' },
+        checked: 'closed',
+        collection: Mybookings::AdobeConnectBooking.adobe_connect_meeting_privacies.keys.map {|key| [t("mybookings.bookings.privacies.#{key}_html"), key]}
+    .js-dynamic-form-element-to-hide
+      = form.input :adobe_connect_participants,
+          input_html: { rows: 3, value: @booking.adobe_connect_participants.join(', '), data: { 'dynamic-form-disables-with': '.js-booking-privacy-type:checked=opened'} },
+          hint: t('mybookings.bookings.hints.participants_hint')
 
 :coffeescript
   $('#adobe_connect_booking_adobe_connect_meeting_room_id').select2

--- a/db/migrate/20180319000000_change_adobe_meeting_privacy_type_keys.rb
+++ b/db/migrate/20180319000000_change_adobe_meeting_privacy_type_keys.rb
@@ -1,0 +1,20 @@
+class ChangeAdobeMeetingPrivacyTypeKeys < ActiveRecord::Migration
+  def change
+    ActiveRecord::Base.record_timestamps = false
+    begin
+      closed_bookings = Mybookings::AdobeConnectBooking.with_deleted.where(adobe_connect_meeting_privacy: 0).load
+      opened_bookings = Mybookings::AdobeConnectBooking.with_deleted.where(adobe_connect_meeting_privacy: 2).load
+
+      closed_bookings.each do |closed_booking|
+        closed_booking.adobe_connect_meeting_privacy = 2
+        closed_booking.save!
+      end
+      opened_bookings.each do |opened_booking|
+        opened_booking.adobe_connect_meeting_privacy = 0
+        opened_booking.save!
+      end
+    ensure
+      ActiveRecord::Base.record_timestamps = true
+    end
+  end
+end


### PR DESCRIPTION
In this pull request, I have changed the order of the privacy options on the new booking form. Also, when is selected the opened option, the participants textarea is hidden.